### PR TITLE
solved ENOENT errors with symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function subdirs (root, maxDepth, cb) {
 
       pending++
 
-      fs.stat(file, processFile)
+      fs.lstat(file, processFile)
 
       function processFile (err, stat) {
         if (err) {


### PR DESCRIPTION
`fs.stat` returns an error on symlinks. This small fix fixes this issue.
I tested it on linux.